### PR TITLE
[TASK] Include PHP 7.1.x as supported PHP version

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = array(
     'conflicts' => '',
     'constraints' => array(
         'depends' => array(
-            'php' => '5.5.0-7.0.99',
+            'php' => '5.5.0-7.1.99',
             'typo3' => '7.0.0-8.7.99',
         ),
         'conflicts' => array(


### PR DESCRIPTION
Seems to be running fine on my webpage (Typo3 7.6.18; PHP 7.1.4). Minification works for both js and html, both Java-Script minifiers are usable. Everything's fine!